### PR TITLE
Bind textvariable to Label subtext

### DIFF
--- a/src/ttkbootstrap/widgets.py
+++ b/src/ttkbootstrap/widgets.py
@@ -750,6 +750,7 @@ class Meter(ttk.Frame):
             text=self._subtext,
             bootstyle=(self._subtextstyle, "metersubtxt"),
             font=self._subtextfont,
+            textvariable=self.labelvar,
         )
 
         self.bind("<<ThemeChanged>>", self._on_theme_change)


### PR DESCRIPTION
Bind textvariable to Label subtext, so we can change the text without configure which is too slow.